### PR TITLE
Fix database commit to 10 seconds insted of 8 minutes

### DIFF
--- a/src/uk/co/amethystdevelopment/acc/AmethystCacheCompactor.java
+++ b/src/uk/co/amethystdevelopment/acc/AmethystCacheCompactor.java
@@ -115,7 +115,7 @@ public class AmethystCacheCompactor extends JavaPlugin
                     Logger.getLogger(AmethystCacheCompactor.class.getName()).log(Level.SEVERE, null, ex);
                 }
             }
-        }.runTaskTimerAsynchronously(this, 0, 10000);
+        }.runTaskTimerAsynchronously(this, 0, 200);
     }
     
     @Override


### PR DESCRIPTION
We were having problems on our server due to the database not commiting data in a reasonable time. This request changes the delay to ticks insted of miliseconds because Bukkit have really stupid variable names. 

We also have removed the hopper listener to avoid item duplication